### PR TITLE
Add matrix to run CI on Python 3.7 through 3.10, Ubuntu & Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,9 +15,9 @@ jobs:
     name: Run unit tests
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         os: [ubuntu-latest, windows-latest]
-        requirements: [".[tests]", ".[compat_tests]"]
+        requirements: ['.[tests]', '.[compat_tests]']
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -40,7 +40,7 @@ jobs:
         run: |
           python -m pip install --no-cache-dir --upgrade pip
           python -m pip install --no-cache-dir ${{ matrix.requirements }}
-        if: steps.restore-cache.outputs.cache-hit != "true"
+        if: steps.restore-cache.outputs.cache-hit != 'true'
 
       - name: Run unit tests
         run: pytest -sv tests/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,17 +13,25 @@ jobs:
 
   test_sampling:
     name: Run unit tests
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        os: [ubuntu-latest, windows-latest]
+        requirements: [".[tests]", ".[compat_tests]"]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
       - name: Setup Python environment
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: ${{ matrix.python-version }}
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install ".[tests]"
+
       - name: Run unit tests
         run: pytest -sv tests/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Python environment
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
         id: restore-cache
         with:
           path: ${{ env.pythonLocation }}
-          key: python-dependencies-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.requirements }}-${{ hashFiles("setup.py") }}-${{ env.pythonLocation }}
+          key: python-dependencies-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.requirements }}-${{ hashFiles('setup.py') }}-${{ env.pythonLocation }}
 
       - name: Install dependencies on cache miss
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,7 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, windows-latest]
         requirements: [".[tests]", ".[compat_tests]"]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
@@ -28,10 +29,18 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install dependencies
+      - name: Try to load cached dependencies
+        uses: actions/cache@v3
+        id: restore-cache
+        with:
+          path: ${{ env.pythonLocation }}
+          key: python-dependencies-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.requirements }}-${{ hashFiles("setup.py") }}-${{ env.pythonLocation }}
+
+      - name: Install dependencies on cache miss
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install ".[tests]"
+          python -m pip install --no-cache-dir --upgrade pip
+          python -m pip install --no-cache-dir ${{ matrix.requirements }}
+        if: steps.restore-cache.outputs.cache-hit != "true"
 
       - name: Run unit tests
         run: pytest -sv tests/

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ README_TEXT = (Path(__file__).parent / "README.md").read_text(encoding="utf-8")
 
 INTEGRATIONS_REQUIRE = ["optuna"]
 
-REQUIRED_PKGS = ["datasets==2.3.2", "sentence-transformers==2.2.2", "evaluate==0.3.0"]
+REQUIRED_PKGS = ["datasets>=2.0.0", "sentence-transformers>=2.0.0", "evaluate>=0.3.0"]
 
 QUALITY_REQUIRE = ["black", "flake8", "isort", "tabulate"]
 
@@ -16,7 +16,15 @@ ONNX_REQUIRE = ["onnxruntime", "onnx", "skl2onnx"]
 
 TESTS_REQUIRE = ["pytest", "pytest-cov"] + ONNX_REQUIRE
 
-EXTRAS_REQUIRE = {"optuna": INTEGRATIONS_REQUIRE, "quality": QUALITY_REQUIRE, "tests": TESTS_REQUIRE, "onnx": ONNX_REQUIRE}
+COMPAT_TESTS_REQUIRE = [requirement.replace(">=", "==") for requirement in REQUIRED_PKGS] + TESTS_REQUIRE
+
+EXTRAS_REQUIRE = {
+    "optuna": INTEGRATIONS_REQUIRE,
+    "quality": QUALITY_REQUIRE,
+    "tests": TESTS_REQUIRE,
+    "onnx": ONNX_REQUIRE,
+    "compat_tests": COMPAT_TESTS_REQUIRE,
+}
 
 
 def combine_requirements(base_keys):

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ README_TEXT = (Path(__file__).parent / "README.md").read_text(encoding="utf-8")
 
 INTEGRATIONS_REQUIRE = ["optuna"]
 
-REQUIRED_PKGS = ["datasets>=2.0.0", "sentence-transformers>=2.2.1", "evaluate>=0.3.0"]
+REQUIRED_PKGS = ["datasets>=2.3.0", "sentence-transformers>=2.2.1", "evaluate>=0.3.0"]
 
 QUALITY_REQUIRE = ["black", "flake8", "isort", "tabulate"]
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ README_TEXT = (Path(__file__).parent / "README.md").read_text(encoding="utf-8")
 
 INTEGRATIONS_REQUIRE = ["optuna"]
 
-REQUIRED_PKGS = ["datasets>=2.0.0", "sentence-transformers>=2.0.0", "evaluate>=0.3.0"]
+REQUIRED_PKGS = ["datasets>=2.0.0", "sentence-transformers>=2.2.1", "evaluate>=0.3.0"]
 
 QUALITY_REQUIRE = ["black", "flake8", "isort", "tabulate"]
 

--- a/src/setfit/exporters/onnx.py
+++ b/src/setfit/exporters/onnx.py
@@ -87,11 +87,15 @@ def export_onnx_setfit_model(setfit_model: OnnxSetFitModel, inputs, output_path,
     for output_name in output_names:
         dynamic_axes_output[output_name] = {0: "batch_size"}
 
+    # Move inputs to the right device
+    target = setfit_model.model_body.device
+    args = tuple(value.to(target) for value in inputs.values())
+
     setfit_model.eval()
     with torch.no_grad():
         torch.onnx.export(
             setfit_model,
-            args=tuple(inputs.values()),
+            args=args,
             f=output_path,
             opset_version=opset,
             input_names=["input_ids", "attention_mask", "token_type_ids"],

--- a/tests/exporters/test_onnx.py
+++ b/tests/exporters/test_onnx.py
@@ -34,6 +34,8 @@ def test_export_onnx_sklearn_head():
         return_token_type_ids=True,
         return_tensors="np",
     )
+    # Map inputs to int64 from int32
+    inputs = {key: value.astype("int64") for key, value in inputs.items()}
 
     session = onnxruntime.InferenceSession(output_path)
 


### PR DESCRIPTION
And to run tests both on the most recent dependencies and on the oldest legal dependencies

This PR is to trigger the CI outside of the main repository, allowing me to do some easier testing.